### PR TITLE
added minimal setup to receive FCM notifications

### DIFF
--- a/lighthouse-android/app/src/main/AndroidManifest.xml
+++ b/lighthouse-android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,18 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Lighthouse"
         tools:targetApi="31">
+
+        <!-- Set custom default icon. This is used when no icon is set for incoming notification messages.
+             See README(https://goo.gl/l4GJaQ) for more. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_launcher_foreground" />
+        <!-- Set color used with incoming notification messages. This is used when no color is set for the incoming
+             notification message. See README(https://goo.gl/6BKBk7) for more. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/teal_700" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -23,6 +35,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".LighthouseFCMService"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/lighthouse-android/app/src/main/java/ua/org/meters/lighthouse/mobile/LighthouseFCMService.kt
+++ b/lighthouse-android/app/src/main/java/ua/org/meters/lighthouse/mobile/LighthouseFCMService.kt
@@ -1,0 +1,76 @@
+package ua.org.meters.lighthouse.mobile
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.media.RingtoneManager
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+/**
+ * Receives messages from Firebase Cloud.
+ */
+class LighthouseFCMService : FirebaseMessagingService() {
+
+    override fun onNewToken(token: String) {
+        Log.d(TAG, "Refreshed token: $token")
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        if (message.notification != null) {
+            sendNotification(message);
+        }
+    }
+
+    /**
+     * Creates a notification.
+     * @param message   FCM notification message
+     */
+    private fun sendNotification(message: RemoteMessage) {
+        val requestCode = 0
+        val intent = Intent(this, MainActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val channelId = getString(R.string.default_notification_channel_id)
+        val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val notificationBuilder = NotificationCompat.Builder(this, channelId)
+            .setContentTitle(getString(R.string.fcm_message))
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentText(message.notification?.body)
+            .setAutoCancel(true)
+            .setSound(defaultSoundUri)
+            .setContentIntent(pendingIntent)
+
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Since android Oreo notification channel is needed.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                "Мій файний дім",
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val notificationId = 0
+        notificationManager.notify(notificationId, notificationBuilder.build())
+    }
+
+    companion object {
+        private const val TAG = "LighthouseFCMService"
+    }
+}

--- a/lighthouse-android/app/src/main/java/ua/org/meters/lighthouse/mobile/MainActivity.kt
+++ b/lighthouse-android/app/src/main/java/ua/org/meters/lighthouse/mobile/MainActivity.kt
@@ -1,9 +1,15 @@
 package ua.org.meters.lighthouse.mobile
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -11,6 +17,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContextCompat
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
 import ua.org.meters.lighthouse.mobile.ui.theme.LighthouseTheme
 
 class MainActivity : ComponentActivity() {
@@ -27,6 +36,47 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+        askNotificationPermission()
+        logRegistrationToken()
+    }
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { isGranted: Boolean ->
+        if (isGranted) {
+            Toast.makeText(baseContext, R.string.will_show_notifications, Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(baseContext, R.string.will_not_show_notifications, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun askNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+            ) {
+                Log.d(TAG, "Notification permission already granted")
+            } else if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
+                Toast.makeText(baseContext, R.string.notifications_needed, Toast.LENGTH_SHORT).show()
+            } else {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        }
+    }
+
+    private fun logRegistrationToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener {task ->
+            if (!task.isSuccessful) {
+                Log.w(TAG, "Cannot get registration token", task.exception)
+                return@OnCompleteListener
+            }
+
+            Log.i(TAG, "Got FCM token: " + task.result)
+        })
+    }
+
+    companion object {
+        private const val TAG = "MainActivity";
     }
 }
 

--- a/lighthouse-android/app/src/main/res/values/strings.xml
+++ b/lighthouse-android/app/src/main/res/values/strings.xml
@@ -1,3 +1,8 @@
 <resources>
     <string name="app_name">Lighthouse</string>
+    <string name="will_show_notifications">Застосунок буде приймати сповіщення</string>
+    <string name="will_not_show_notifications">Застосунок не буде приймати сповіщення</string>
+    <string name="notifications_needed">Будь ласка, надайте дозвіл для отримання сповіщень у застосунку щоб невідкладно отримувати оновлення інформації</string>
+    <string name="default_notification_channel_id">ua.org.meters.lighthouse.mobile</string>
+    <string name="fcm_message">Lighthouse</string>
 </resources>

--- a/lighthouse-android/gradle/libs.versions.toml
+++ b/lighthouse-android/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase" }
-firebase-analytics = { group = "com.google.firebase", name = "firebase-analystics" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
 [plugins]


### PR DESCRIPTION
Added `FirebaseMessagingService` implementation which shows notification when new message arrives.

On main activity create, app check for notification permission and requests one if not granted.

Provides minimal resolution of #8 