### PR TITLE
added firmware for power sensor

### DIFF
--- a/lighthouse-pwr-sensor/PowerSensor/PowerSensor.ino
+++ b/lighthouse-pwr-sensor/PowerSensor/PowerSensor.ino
@@ -1,0 +1,76 @@
+#include <Arduino.h>
+
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+
+#include <ESP8266HTTPClient.h>
+
+#include <WiFiClient.h>
+
+#include "settings.h"
+
+ESP8266WiFiMulti WiFiMulti;
+
+void setup() {
+  Serial.begin(115200);
+
+  Serial.println();
+  Serial.println();
+  Serial.println();
+
+  for (uint8_t t = 4; t > 0; t--) {
+    Serial.printf("[SETUP] WAIT %d...\n", t);
+    Serial.flush();
+    delay(1000);
+  }
+
+  WiFi.mode(WIFI_STA);
+  WiFiMulti.addAP(WIFI_SSID, WIFI_PASSWORD);
+
+  pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+  // wait for WiFi connection
+  if ((WiFiMulti.run() == WL_CONNECTED)) {
+
+    WiFiClient client;
+    HTTPClient http;
+
+    String url = String(SERVER_URL);
+    url.concat("/api/sensor/report");
+
+    if (http.begin(client, url)) {
+
+      Serial.print("Sending request to the server... ");
+      int httpCode = http.POST("");
+
+      // httpCode will be negative on error
+      if (httpCode == HTTP_CODE_OK) {
+        Serial.println("Successful");
+        blink(1);
+      } else {
+        Serial.printf("ERROR: %d\n", httpCode);
+        blink(3);
+      }
+
+      http.end();
+    } else {
+      Serial.println("ERROR: Unable to connect");
+      blink(3);
+    }
+  } else {
+    Serial.println("WiFi is not connected");
+  }
+
+  delay(REQUEST_RATE);
+}
+
+void blink(int times) {
+    for (int i = 0; i < times; ++i) {
+      digitalWrite(LED_BUILTIN, LOW);
+      delay(100);
+      digitalWrite(LED_BUILTIN, HIGH);
+      delay(300);
+    }
+}

--- a/lighthouse-pwr-sensor/PowerSensor/settings.h
+++ b/lighthouse-pwr-sensor/PowerSensor/settings.h
@@ -1,0 +1,5 @@
+#define WIFI_SSID "SSID"
+#define WIFI_PASSWORD "password"
+#define SERVER_URL "http://lighthouse.meters.org.ua"
+#define REQUEST_RATE 30000
+ 


### PR DESCRIPTION
Added Arduino sketch for ESP8266 chip. 

In the main loop an empty HTTP POST request is sent to _/api/sensor/report_ periodically. If the request is successful, built-in led blink one time. If there is an error - led blinks 3 times. Also, debug information is printed to the serial output.

`settings.h` contain WiFi network credentials, server address and request rate. This file is supposed to be overridden before flashing the firmware.

This meets the minimal requirements for v 0.1 and resolves #5.