### PR TITLE
mobile: added notification permission request dialog

### DIFF
--- a/lighthouse-android/app/src/main/res/values/strings.xml
+++ b/lighthouse-android/app/src/main/res/values/strings.xml
@@ -2,7 +2,10 @@
     <string name="app_name">Lighthouse</string>
     <string name="will_show_notifications">Застосунок буде приймати сповіщення</string>
     <string name="will_not_show_notifications">Застосунок не буде приймати сповіщення</string>
+    <string name="notifications_needed_title">Дозвіл на нотифікації</string>
     <string name="notifications_needed">Будь ласка, надайте дозвіл для отримання сповіщень у застосунку щоб невідкладно отримувати оновлення інформації</string>
+    <string name="dialog_request">Надати</string>
+    <string name="dialog_cancel">Відмінити</string>
     <string name="default_notification_channel_id">ua.org.meters.lighthouse.mobile</string>
     <string name="fcm_message">Lighthouse</string>
     <string name="screen_title">Мій Файний Дім</string>


### PR DESCRIPTION
This adds a permission request justification dialog if the user didn't allow notifications on first app start.

<img src="https://github.com/kuzjka/lighthouse-community/assets/1489303/82bad109-2b6b-437e-a72a-bbbcf41c4c35" width="320">
