### PR TITLE
relaxed build JDK requirements

### DIFF
--- a/lighthouse-server/build.gradle
+++ b/lighthouse-server/build.gradle
@@ -8,9 +8,7 @@ group = 'ua.org.meters'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+	sourceCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {


### PR DESCRIPTION
This retains Java 17 compatibility but allows to build using newer JDKs.