### PR TITLE
added FCM notifier implementation

### DIFF
--- a/lighthouse-server/.gitignore
+++ b/lighthouse-server/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Firebase credentials file ###
+firebase-credentials.json

--- a/lighthouse-server/build.gradle
+++ b/lighthouse-server/build.gradle
@@ -18,6 +18,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'com.google.firebase:firebase-admin:9.3.0'
 	implementation 'org.flywaydb:flyway-core'
 	runtimeOnly 'com.h2database:h2'
 

--- a/lighthouse-server/src/main/java/ua/org/meters/lighthouse/config/AppConfig.java
+++ b/lighthouse-server/src/main/java/ua/org/meters/lighthouse/config/AppConfig.java
@@ -2,6 +2,7 @@ package ua.org.meters.lighthouse.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import ua.org.meters.lighthouse.notification.FCMNotifier;
 import ua.org.meters.lighthouse.notification.LoggingNotifier;
 import ua.org.meters.lighthouse.notification.NotificationManager;
 
@@ -15,9 +16,10 @@ public class AppConfig {
     }
 
     @Bean
-    public NotificationManager notificationManager() {
+    public NotificationManager notificationManager(FCMNotifier fcmNotifier) {
         NotificationManager manager = new NotificationManager();
         manager.addPowerNotifier(new LoggingNotifier());
+        manager.addPowerNotifier(fcmNotifier);
         return manager;
     }
 }

--- a/lighthouse-server/src/main/java/ua/org/meters/lighthouse/notification/FCMNotifier.java
+++ b/lighthouse-server/src/main/java/ua/org/meters/lighthouse/notification/FCMNotifier.java
@@ -1,0 +1,60 @@
+package ua.org.meters.lighthouse.notification;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Sends power notifications to mobile app using Firebase Cloud Messaging.
+ */
+@Service
+public class FCMNotifier implements PowerNotifier {
+    private static final Logger logger = LoggerFactory.getLogger(FCMNotifier.class);
+
+    public static final String TOPIC = "power";
+
+    public FCMNotifier(@Value("${lighthouse.fcm.creds-file}") String credentialsPath) throws IOException {
+        GoogleCredentials credentials;
+        try (InputStream in = new FileInputStream(credentialsPath)) {
+            credentials = GoogleCredentials.fromStream(in);
+        }
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(credentials)
+                .build();
+
+        FirebaseApp.initializeApp(options);
+    }
+
+    @Override
+    public void notifyPower(boolean powerOn) {
+        logger.debug("Notifying with FCM on state change: {}", powerOn);
+        Message message = Message.builder()
+                .setTopic(TOPIC)
+                .setNotification(Notification.builder()
+                        .setTitle("Lighthouse")
+                        .setBody(powerOn ? "Світло з'явилось!" : "Світло відключено")
+                        .build())
+                .putData("power", Boolean.toString(powerOn))
+                .build();
+
+        String messageId;
+        try {
+            messageId = FirebaseMessaging.getInstance().send(message);
+            logger.debug("Notification successful, message ID: {}", messageId);
+        } catch (FirebaseMessagingException e) {
+            throw new NotificationException("Cannot notify with FCM", e);
+        }
+    }
+}

--- a/lighthouse-server/src/main/java/ua/org/meters/lighthouse/notification/NotificationException.java
+++ b/lighthouse-server/src/main/java/ua/org/meters/lighthouse/notification/NotificationException.java
@@ -1,0 +1,24 @@
+package ua.org.meters.lighthouse.notification;
+
+/**
+ * Thrown if user notification failed.
+ */
+public class NotificationException extends RuntimeException {
+
+    /**
+     * Creates new exception.
+     * @param message   Error message
+     */
+    public NotificationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates new exception.
+     * @param message   Error message
+     * @param cause     Exception which caused notification failure
+     */
+    public NotificationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/lighthouse-server/src/main/resources/application.yaml
+++ b/lighthouse-server/src/main/resources/application.yaml
@@ -3,6 +3,8 @@ lighthouse:
     checkRate: 30  # time in seconds between sensor state checks
     timeout: 60    # time in seconds to pass without reports before the sensor is considered unpowered
     password: changeme
+  fcm:
+    creds-file: firebase-credentials.json
 
 logging:
   level:


### PR DESCRIPTION
Resolves #14 

Adds notifier for Firebase Cloud Messaging service, which delivers push notifications to mobile app users.
FCM needs authentication, credentials are supplied from Firebase web console as a json file. Path to the file is set in app properties.

As we have a single sensor in this version, we use a shared topic, called "power" and subscribe all mobile clients to this topic.