### PR TITLE
sensor: HTTPS and basic auth

### DIFF
--- a/lighthouse-pwr-sensor/PowerSensor/PowerSensor.ino
+++ b/lighthouse-pwr-sensor/PowerSensor/PowerSensor.ino
@@ -4,10 +4,12 @@
 #include <ESP8266WiFiMulti.h>
 
 #include <ESP8266HTTPClient.h>
+#include <WiFiClientSecureBearSSL.h>
 
 #include <WiFiClient.h>
 
 #include "settings.h"
+#include "cert.h"
 
 ESP8266WiFiMulti WiFiMulti;
 
@@ -34,13 +36,16 @@ void loop() {
   // wait for WiFi connection
   if ((WiFiMulti.run() == WL_CONNECTED)) {
 
-    WiFiClient client;
+    std::unique_ptr<BearSSL::WiFiClientSecure> client(new BearSSL::WiFiClientSecure);
+    client->setFingerprint(fingerprint);
+
     HTTPClient http;
 
     String url = String(SERVER_URL);
     url.concat("/api/sensor/report");
 
-    if (http.begin(client, url)) {
+    if (http.begin(*client, url)) {
+      http.setAuthorization(USERNAME, PASSWORD);
 
       Serial.print("Sending request to the server... ");
       int httpCode = http.POST("");

--- a/lighthouse-pwr-sensor/PowerSensor/cert.h
+++ b/lighthouse-pwr-sensor/PowerSensor/cert.h
@@ -1,0 +1,3 @@
+#pragma once
+
+const char fingerprint [] PROGMEM = "8C:08:F9:FA:80:95:09:CD:AB:3D:C9:53:9C:C5:D1:D0:5A:28:3D:C7";

--- a/lighthouse-pwr-sensor/PowerSensor/settings.h
+++ b/lighthouse-pwr-sensor/PowerSensor/settings.h
@@ -2,4 +2,5 @@
 #define WIFI_PASSWORD "password"
 #define SERVER_URL "http://lighthouse.meters.org.ua"
 #define REQUEST_RATE 30000
- 
+#define USERNAME "user"
+#define PASSWORD "pa33w0rd"


### PR DESCRIPTION
Adds HTTPS support for sensor. TLS is verified by temporary certificate fingerprint.
Basic HTTP Authorization is added. Username and passwords are set in `settings.h`.